### PR TITLE
chore: delete `FUNDING.yml`

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: [antfu]


### PR DESCRIPTION
We don't override the organization-wide `FUNDING.yml` file in our other repos and just use the organization default.